### PR TITLE
Draft out local feature for debugging only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2018"
 gfaas-macro = { path = "crates/macro" }
 gwasm-api = "0.2"
 tempfile = "3.1"
+tokio = { version = "0.2", features = ["blocking"] }
+# sp-wasm-engine = "0.3"
+sp-wasm-engine = { path = "../sp-wasm/sp-wasm-engine" }
+lazy_static = "1.4"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ gfaas-macro = { path = "crates/macro" }
 gwasm-api = "0.2"
 tempfile = "3.1"
 tokio = { version = "0.2", features = ["blocking"] }
-# sp-wasm-engine = "0.3"
-sp-wasm-engine = { path = "../sp-wasm/sp-wasm-engine" }
+sp-wasm-engine = "0.4"
 lazy_static = "1.4"
 
 [workspace]

--- a/crates/macro/src/logic.rs
+++ b/crates/macro/src/logic.rs
@@ -188,11 +188,45 @@ pub(super) fn remote_fn_impl(attrs: GwasmAttrs, f: GwasmFn, preserved: TokenStre
     // Compute out dir
     let out_dir = env::var("GFAAS_OUT_DIR").expect("GFAAS_OUT_DIR should be defined");
     let local_testing = env::var("GFAAS_LOCAL");
-    let fn_body = f.body;
+    let input_data = args_pats[0].clone();
     let output = if let Ok(_) = local_testing {
         quote! {
             #fn_vis async fn #fn_ident(#fn_args) #fn_ret {
-                #fn_body
+                use gfaas::__private::sp_wasm_engine::prelude::*;
+                use gfaas::__private::tokio::task;
+                use gfaas::__private::tempfile::tempdir;
+                use gfaas::__private::lazy_static::lazy_static;
+                use std::fs;
+                use std::mem::ManuallyDrop;
+                use std::path::Path;
+                use std::sync::Arc;
+
+                lazy_static! {
+                    static ref ENGINE: Arc<JSEngine> = JSEngine::init().unwrap();
+                }
+
+                let data = Vec::from(#input_data);
+                let engine = Arc::clone(&ENGINE);
+
+                task::spawn_blocking(move || {
+                    let js = Path::new(#out_dir).join("bin").join(format!("{}.js", stringify!(#fn_ident)));
+                    let wasm = Path::new(#out_dir).join("bin").join(format!("{}.wasm", stringify!(#fn_ident)));
+                    let workspace = ManuallyDrop::new(tempdir().unwrap());
+                    let input_dir = workspace.path().join("in");
+                    let output_dir = workspace.path().join("out");
+                    fs::create_dir(&input_dir).unwrap();
+                    fs::create_dir(&output_dir).unwrap();
+                    fs::write(input_dir.join("in"), data).unwrap();
+
+                    Sandbox::new(engine)
+                        .and_then(|sandbox| sandbox.set_exec_args(vec!["in", "out"]))
+                        .and_then(|sandbox| sandbox.load_input_files(input_dir))
+                        .and_then(|sandbox| sandbox.run(js, wasm))
+                        .and_then(|sandbox| sandbox.save_output_files(&output_dir, vec!["out"]))
+                        .unwrap();
+
+                    fs::read(output_dir.join("out")).unwrap()
+                }).await.unwrap()
             }
         }
     } else {

--- a/examples/sum/src/main.rs
+++ b/examples/sum/src/main.rs
@@ -22,7 +22,6 @@ async fn main() {
     let output = input.fold(0u64, |acc, x| async move {
         let x = serde_json::to_vec(&x).unwrap();
         let out: Vec<u8> = partial_sum(&x).await;
-        println!("{:?}", out);
         let out: u64 = serde_json::from_slice(&out).unwrap();
         acc + out
     });

--- a/examples/sum/src/main.rs
+++ b/examples/sum/src/main.rs
@@ -22,6 +22,7 @@ async fn main() {
     let output = input.fold(0u64, |acc, x| async move {
         let x = serde_json::to_vec(&x).unwrap();
         let out: Vec<u8> = partial_sum(&x).await;
+        println!("{:?}", out);
         let out: u64 = serde_json::from_slice(&out).unwrap();
         acc + out
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod __private {
     pub use gwasm_api;
     pub use tempfile;
+    pub use sp_wasm_engine;
+    pub use tokio;
+    pub use lazy_static;
 }
 
 pub use gfaas_macro::remote_fn;


### PR DESCRIPTION
Supplying `--local` flag to `gfaas` cli build tool will now pull in `sp-wasm-engine` crate and run the generated gfaas Wasm modules locally instead of distributing them on the Golem network. There is still a lot of work that needs to be done, but nonetheless, this currently works.

Example build command for local-only build:

```
gfaas build --local
```

And running:

```
gfaas run --local
```