### PR TITLE
Cleanup proc-macro options and add simple auto ser/de

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -107,6 +107,14 @@ fn build(cwd: &Path, local: bool, release: bool, args: &Vec<String>) {
             .as_table_mut()
             .unwrap()
             .insert("dependencies".to_owned(), deps.into());
+    // TODO insert serde_json dep
+    } else {
+        gfaas_toml.as_table_mut().unwrap().insert(
+            "dependencies".to_owned(),
+            toml::toml! {
+                serde_json = "1"
+            },
+        );
     }
 
     fs::write(
@@ -136,8 +144,7 @@ fn build(cwd: &Path, local: bool, release: bool, args: &Vec<String>) {
         cmd.arg("--release");
     }
     let _cmd_out = cmd.output().unwrap();
-    // Next, run cargo build --target=wasm32-unknown-emscripten on gfaas_modules
-    // crate.
+    // Next, run cargo build --target=wasm32-wasi on gfaas_modules crate.
     let mut cmd = Command::new("cargo");
     cmd.arg("install")
         .arg("--target=wasm32-wasi")

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -4,16 +4,13 @@ use gfaas::remote_fn;
     datadir = "/Users/kubkon/dev/yagna/ya-req",
     budget = 100,
 )]
-pub fn hello(r#in: &[u8]) -> Vec<u8> {
-    println!("START");
-    let s = std::str::from_utf8(r#in).unwrap().to_uppercase();
-    println!("STOP");
-    s.as_bytes().to_vec()
+pub fn hello(r#in: String) -> String {
+    r#in.to_uppercase().to_string()
 }
 
 #[actix_rt::main]
 async fn main() {
     let r#in = "hey there gwasm";
-    let out = hello(r#in.as_bytes()).await;
-    println!("in: {}, out: {}", r#in, String::from_utf8(out).unwrap());
+    let out = hello("hey there gwasm".to_string()).await;
+    println!("in: {}, out: {}", r#in, out)
 }

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -2,9 +2,7 @@ use gfaas::remote_fn;
 
 #[remote_fn(
     datadir = "/Users/kubkon/dev/yagna/ya-req",
-    rpc_address = "127.0.0.1",
-    rpc_port = 61000,
-    net = "testnet"
+    budget = 100,
 )]
 pub fn hello(r#in: &[u8]) -> Vec<u8> {
     println!("START");

--- a/examples/sum/src/main.rs
+++ b/examples/sum/src/main.rs
@@ -3,9 +3,7 @@ use futures::stream::{self, StreamExt};
 
 #[remote_fn(
     datadir = "/Users/kubkon/dev/yagna/ya-req",
-    rpc_address = "127.0.0.1",
-    rpc_port = 61000,
-    net = "testnet"
+    budget = 100,
 )]
 fn partial_sum(r#in: &[u8]) -> Vec<u8> {
     let s: Vec<u64> = serde_json::from_slice(r#in).unwrap();
@@ -16,7 +14,7 @@ fn partial_sum(r#in: &[u8]) -> Vec<u8> {
 #[actix_rt::main]
 async fn main() {
     let input: Vec<u64> = (0..100).collect();
-    let input: Vec<_> = input.chunks(10).collect();
+    let input: Vec<_> = input.chunks(50).collect();
     let input = stream::iter(input);
 
     let output = input.fold(0u64, |acc, x| async move {

--- a/examples/sum/src/main.rs
+++ b/examples/sum/src/main.rs
@@ -5,10 +5,8 @@ use futures::stream::{self, StreamExt};
     datadir = "/Users/kubkon/dev/yagna/ya-req",
     budget = 100,
 )]
-fn partial_sum(r#in: &[u8]) -> Vec<u8> {
-    let s: Vec<u64> = serde_json::from_slice(r#in).unwrap();
-    let s: u64 = s.into_iter().sum();
-    serde_json::to_vec(&s).unwrap()
+fn partial_sum(r#in: Vec<u64>) -> u64 {
+    r#in.into_iter().sum()
 }
 
 #[actix_rt::main]
@@ -18,9 +16,7 @@ async fn main() {
     let input = stream::iter(input);
 
     let output = input.fold(0u64, |acc, x| async move {
-        let x = serde_json::to_vec(&x).unwrap();
-        let out: Vec<u8> = partial_sum(&x).await;
-        let out: u64 = serde_json::from_slice(&out).unwrap();
+        let out = partial_sum(x.to_vec()).await;
         acc + out
     });
     let output = output.await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod __private {
     pub use wasi_rt;
     pub use ya_requestor_sdk;
     pub use ya_agreement_utils;
+    pub use serde_json;
 
     #[allow(unused)]
     pub mod package {


### PR DESCRIPTION
This PR adds budget option to the proc-macro **and** removes options that were specific to the Clay Golem and gWasm. At the same time, it also adds a PoC for simple automatic serialization/deserialization of types based on `serde` crate.