### PR TITLE
Update task scheduling in mandelbrot example

### DIFF
--- a/examples/bellman/src/main.rs
+++ b/examples/bellman/src/main.rs
@@ -1,4 +1,3 @@
-use gfaas::remote_fn;
 use bellman::{
     gadgets::{
         boolean::{AllocatedBit, Boolean},
@@ -7,6 +6,7 @@ use bellman::{
     },
     groth16, Circuit, ConstraintSystem, SynthesisError,
 };
+use gfaas::remote_fn;
 use pairing::{bls12_381::Bls12, Engine};
 use rand::rngs::OsRng;
 use std::{
@@ -15,10 +15,7 @@ use std::{
 };
 use structopt::StructOpt;
 
-#[remote_fn(
-    datadir = "/Users/kubkon/dev/yagna/ya-req",
-    budget = 1000,
-)]
+#[remote_fn(datadir = "/Users/kubkon/dev/yagna/ya-req", budget = 1000)]
 fn generate_proof_on_golem(params: Vec<u8>, preimage: Vec<u8>) -> Vec<u8> {
     use bellman::{
         gadgets::{
@@ -82,7 +79,9 @@ fn generate_proof_on_golem(params: Vec<u8>, preimage: Vec<u8>) -> Vec<u8> {
             let preimage_bits = bit_values
                 .into_iter()
                 .enumerate()
-                .map(|(i, b)| AllocatedBit::alloc(cs.namespace(|| format!("preimage bit {}", i)), b))
+                .map(|(i, b)| {
+                    AllocatedBit::alloc(cs.namespace(|| format!("preimage bit {}", i)), b)
+                })
                 .map(|b| b.map(Boolean::from))
                 .collect::<Result<Vec<_>, _>>()?;
 

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -1,9 +1,6 @@
 use gfaas::remote_fn;
 
-#[remote_fn(
-    datadir = "/Users/kubkon/dev/yagna/ya-req",
-    budget = 100,
-)]
+#[remote_fn(datadir = "/Users/kubkon/dev/yagna/ya-req", budget = 100)]
 pub fn hello(r#in: String) -> String {
     r#in.to_uppercase().to_string()
 }

--- a/examples/sum/src/main.rs
+++ b/examples/sum/src/main.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
-use gfaas::remote_fn;
 use futures::stream::{self, TryStreamExt};
+use gfaas::remote_fn;
 
-#[remote_fn(
-    datadir = "/Users/kubkon/dev/yagna/ya-req",
-    budget = 100,
-)]
+#[remote_fn(datadir = "/Users/kubkon/dev/yagna/ya-req", budget = 100)]
 fn partial_sum(r#in: Vec<u64>) -> u64 {
     r#in.into_iter().sum()
 }


### PR DESCRIPTION
This PR redoes how we deal with tasks in Mandelbrot in that instead of joining a couple of futures together at once, we instead create an async stream to process the tasks. This plays better with `yarapi - 0.1.0`.