### PR TITLE
Refactor returned error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfaas"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jakub Konka <kubkon@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"
@@ -11,7 +11,7 @@ documentation = "https://github.com/golemfactory/gfaas"
 description = "Distribute heavy-workload functions on Golem Network or other backend"
 
 [dependencies]
-gfaas-macro = { path = "crates/macro", version = "0.1" }
+gfaas-macro = { path = "crates/macro", version = "0.2" }
 anyhow = "1"
 dotenv = "0.15"
 futures = "0.3"
@@ -22,7 +22,6 @@ tokio = { version = "0.2", features = ["blocking"] }
 ya-runtime-wasi = "0.2"
 yarapi = "0.1"
 ya-agreement-utils = "0.1"
-thiserror = "1.0.20"
 
 [workspace]
 members = [

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfaas-macro"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jakub Konka <kubkon@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"

--- a/crates/macro/src/logic.rs
+++ b/crates/macro/src/logic.rs
@@ -208,7 +208,7 @@ pub(super) fn remote_fn_impl(attrs: GwasmAttrs, f: GwasmFn, preserved: TokenStre
     };
 
     let output = quote! {
-        #fn_vis async fn #fn_ident(#fn_args) -> gfaas::__private::anyhow::Result<#return_type> {
+        #fn_vis async fn #fn_ident(#fn_args) -> std::result::Result<#return_type, gfaas::Error> {
             enum RunType {
                 Local,
                 Golem,
@@ -276,7 +276,7 @@ pub(super) fn remote_fn_impl(attrs: GwasmAttrs, f: GwasmFn, preserved: TokenStre
                     Ok(res)
                 }).await?
             } else {
-                use gfaas::__private::anyhow::{Context, anyhow};
+                use gfaas::__private::anyhow::{self, Context, anyhow};
                 use gfaas::__private::dotenv;
                 use gfaas::__private::futures::future::{select, FutureExt};
                 use gfaas::__private::tokio::task;

--- a/examples/bellman/Cargo.toml
+++ b/examples/bellman/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = "0.1"
+gfaas = { path = "../../", version = "0.1" }
 anyhow = "1"
 actix-rt = "1"
 base64 = "0.12"

--- a/examples/bellman/Cargo.toml
+++ b/examples/bellman/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = { path = "../../", version = "0.1" }
+gfaas = { path = "../../", version = "0.2" }
 anyhow = "1"
 actix-rt = "1"
 base64 = "0.12"

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -5,6 +5,5 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = "0.1"
-anyhow = "1"
+gfaas = { path = "../../", version = "0.1" }
 actix-rt = "1"

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = { path = "../../", version = "0.1" }
+gfaas = { path = "../../", version = "0.2" }
 actix-rt = "1"

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -6,10 +6,14 @@ pub fn hello(r#in: String) -> String {
 }
 
 #[actix_rt::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
     let r#in = "hey there gwasm";
-    let out = hello("hey there gwasm".to_string()).await?;
+    let out = match hello("hey there gwasm".to_string()).await {
+        Ok(out) => out,
+        Err(err) => {
+            eprintln!("Unexpected error occurred: {}", err);
+            return;
+        }
+    };
     println!("in: {}, out: {}", r#in, out);
-
-    Ok(())
 }

--- a/examples/mandelbrot/Cargo.toml
+++ b/examples/mandelbrot/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 actix-rt = "1"
 anyhow = "1"
-gfaas = { path = "../../", version = "0.1" }
+gfaas = { path = "../../", version = "0.2" }
 futures = "0.3"
 png = "0.16"
 structopt = "0.3"

--- a/examples/mandelbrot/Cargo.toml
+++ b/examples/mandelbrot/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 actix-rt = "1"
 anyhow = "1"
-gfaas = "0.1"
+gfaas = { path = "../../", version = "0.1" }
 futures = "0.3"
 png = "0.16"
 structopt = "0.3"

--- a/examples/sum/Cargo.toml
+++ b/examples/sum/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = "0.1"
-anyhow = "1"
+gfaas = { path = "../../", version = "0.1" }
 actix-rt = "1"
 futures = "0.3"
 serde_json = "1"

--- a/examples/sum/Cargo.toml
+++ b/examples/sum/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = { path = "../../", version = "0.1" }
+gfaas = { path = "../../", version = "0.2" }
 actix-rt = "1"
 futures = "0.3"
 serde_json = "1"

--- a/examples/sum/src/main.rs
+++ b/examples/sum/src/main.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use futures::stream::{self, TryStreamExt};
 use gfaas::remote_fn;
 
@@ -8,18 +7,23 @@ fn partial_sum(r#in: Vec<u64>) -> u64 {
 }
 
 #[actix_rt::main]
-async fn main() -> Result<()> {
+async fn main() {
     let input: Vec<u64> = (0..100).collect();
-    let input: Vec<Result<_>> = input.chunks(10).map(|x| Ok(x)).collect();
+    let input: Vec<Result<_, gfaas::Error>> = input.chunks(10).map(|x| Ok(x)).collect();
     let input = stream::iter(input);
 
     let output = input.try_fold(0u64, |acc, x| async move {
         let out = partial_sum(x.to_vec()).await?;
         Ok(acc + out)
     });
-    let output = output.await?;
-    println!("{:?}", output);
-    assert_eq!((0..100).sum::<u64>(), output);
 
-    Ok(())
+    let sum = match output.await {
+        Ok(sum) => sum,
+        Err(err) => {
+            eprintln!("Unexpected error occurred {}", err);
+            return;
+        }
+    };
+    assert_eq!((0..100).sum::<u64>(), sum);
+    println!("Calculated sum: {}", sum);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //! expands into
 //!
 //! ```rust,ignore
-//! async fn hello(input: String) -> Result<String, anyhow::Error>;
+//! async fn hello(input: String) -> Result<String, gfaas::Error>;
 //! ```
 //!
 //! Therefore, it is important to remember that you need to run the function in an async block
@@ -224,3 +224,7 @@ pub mod __private {
 /// fn hello(input: String) -> String;
 /// ```
 pub use gfaas_macro::remote_fn;
+
+/// Re-export of `anyhow::Error` which is the default type returned by the expanded
+/// `gfaas::remote_fn`-annotated function.
+pub use anyhow::Error;


### PR DESCRIPTION
Previously, importing `gfaas` would require to the user to also
manually import `anyhow` crate. This PR changes this so that `gfaas`
now re-export `anyhow::Error` as `gfaas::Error` which is returned
from the `gfaas::remote_fn` annotated function:

```
std::result::Result<T, gfaas::Error>
```

Also, clean up parsing input/output args, and bump version to 0.2.0.