### PR TITLE
Update to yarapi 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfaas"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jakub Konka <kubkon@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"
@@ -11,16 +11,15 @@ documentation = "https://github.com/golemfactory/gfaas"
 description = "Distribute heavy-workload functions on Golem Network or other backend"
 
 [dependencies]
-gfaas-macro = { path = "crates/macro", version = "0.2" }
+gfaas-macro = { path = "crates/macro", version = "0.3.0" }
 anyhow = "1"
-dotenv = "0.15"
 futures = "0.3"
 zip = "0.5"
 serde_json = "1"
 tempfile = "3.1"
 tokio = { version = "0.2", features = ["blocking"] }
 ya-runtime-wasi = "0.2"
-yarapi = "0.1"
+yarapi = "0.2"
 ya-agreement-utils = "0.1"
 
 [workspace]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfaas-cli"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Jakub Konka <kubkon@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -153,6 +153,7 @@ fn build(release: bool, args: &[String]) -> Result<()> {
             args.iter()
                 .filter(|x| x.as_str() != "--release" && !x.contains("--target-dir")),
         )
+        .envs(env::vars())
         .env("CARGO_TARGET_DIR", "target")
         .env("GFAAS_OUT_DIR", &out_dir)
         .stdout(Stdio::inherit())
@@ -226,6 +227,7 @@ fn run(release: bool, args: &[String]) -> Result<()> {
             args.iter()
                 .filter(|x| x.as_str() != "--release" && !x.contains("--target-dir")),
         )
+        .envs(env::vars())
         .env("CARGO_TARGET_DIR", "target")
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
@@ -241,6 +243,7 @@ fn clean(args: &[String]) -> Result<()> {
     let mut cmd = Command::new("cargo");
     cmd.arg("clean")
         .args(args.iter().filter(|x| !x.contains("--target-dir")))
+        .envs(env::vars())
         .env("CARGO_TARGET_DIR", "target")
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfaas-macro"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jakub Konka <kubkon@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"

--- a/examples/bellman/Cargo.toml
+++ b/examples/bellman/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = { path = "../../", version = "0.2" }
+pretty_env_logger = "0.4"
+gfaas = { path = "../../", version = "0.3" }
 anyhow = "1"
 actix-rt = "1"
 base64 = "0.12"

--- a/examples/bellman/src/main.rs
+++ b/examples/bellman/src/main.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use structopt::StructOpt;
 
-#[remote_fn(datadir = "/Users/kubkon/dev/yagna/ya-req", budget = 1000)]
+#[remote_fn(budget = 1000, timeout = 900, subnet = "devnet-alpha.2")]
 fn generate_proof_on_golem(params: Vec<u8>, preimage: Vec<u8>) -> Vec<u8> {
     use bellman::{
         gadgets::{
@@ -282,6 +282,7 @@ async fn verify_proof<S: AsRef<str>, P1: AsRef<Path>, P2: AsRef<Path>>(
 
 #[actix_rt::main]
 async fn main() -> anyhow::Result<()> {
+    pretty_env_logger::init();
     let opt = Opt::from_args();
     match opt {
         Opt::GenerateParams => generate_params().await?,

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = { path = "../../", version = "0.2" }
+gfaas = { path = "../../", version = "0.3" }
 actix-rt = "1"
+pretty_env_logger = "0.4"

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -1,12 +1,13 @@
 use gfaas::remote_fn;
 
-#[remote_fn(datadir = "/Users/kubkon/dev/yagna/ya-req", budget = 100)]
+#[remote_fn(budget = 100, timeout = 900, subnet = "devnet-alpha.2")]
 pub fn hello(r#in: String) -> String {
     r#in.to_uppercase().to_string()
 }
 
 #[actix_rt::main]
 async fn main() {
+    pretty_env_logger::init();
     let r#in = "hey there gwasm";
     let out = match hello("hey there gwasm".to_string()).await {
         Ok(out) => out,

--- a/examples/mandelbrot/Cargo.toml
+++ b/examples/mandelbrot/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2018"
 [dependencies]
 actix-rt = "1"
 anyhow = "1"
-gfaas = { path = "../../", version = "0.2" }
+gfaas = { path = "../../", version = "0.3" }
 futures = "0.3"
 png = "0.16"
+pretty_env_logger = "0.4"
 structopt = "0.3"
 
 [gfaas_dependencies]

--- a/examples/mandelbrot/src/main.rs
+++ b/examples/mandelbrot/src/main.rs
@@ -7,7 +7,7 @@ use gfaas::remote_fn;
 use std::{fs::File, io::BufWriter, sync::Arc};
 use structopt::StructOpt;
 
-#[remote_fn(datadir = "/Users/kubkon/dev/yagna/ya-req", budget = 1000)]
+#[remote_fn(budget = 1000, timeout = 900, subnet = "devnet-alpha.2")]
 fn compute_rectangle(start_y: u32, end_y: u32, width: u32, height: u32) -> Vec<u32> {
     use num_complex::Complex;
 
@@ -62,7 +62,7 @@ struct Opt {
     in_parallel: u32,
 }
 
-const MAX_CONCURRENT_JOBS: usize = 1; // this is fixed in yarapi >= v0.2
+const MAX_CONCURRENT_JOBS: usize = 4;
 
 #[actix_rt::main]
 async fn main() -> Result<()> {

--- a/examples/sum/Cargo.toml
+++ b/examples/sum/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-gfaas = { path = "../../", version = "0.2" }
+gfaas = { path = "../../", version = "0.3" }
 actix-rt = "1"
 futures = "0.3"
 serde_json = "1"
+pretty_env_logger = "0.4"

--- a/examples/sum/src/main.rs
+++ b/examples/sum/src/main.rs
@@ -5,15 +5,16 @@ use futures::{
 use gfaas::remote_fn;
 use std::sync::Arc;
 
-#[remote_fn(datadir = "/Users/kubkon/dev/yagna/ya-req", budget = 100)]
+#[remote_fn(budget = 100, timeout = 900, subnet = "devnet-alpha.2")]
 fn partial_sum(r#in: Vec<u64>) -> u64 {
     r#in.into_iter().sum()
 }
 
-const MAX_CONCURRENT_JOBS: usize = 1; // this is fixed in yarapi >= 0.2
+const MAX_CONCURRENT_JOBS: usize = 2;
 
 #[actix_rt::main]
 async fn main() {
+    pretty_env_logger::init();
     let input: Vec<u64> = (0..100).collect();
     let input = stream::iter(input.chunks(10).map(Ok));
     let sums = Arc::new(Mutex::new(Vec::new()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,6 @@ pub mod __private {
     //! This is a private module. The stability of this API is not guaranteed and may change
     //! without notice in the future.
     pub use anyhow;
-    pub use dotenv;
     pub use futures;
     pub use serde_json;
     pub use tempfile;


### PR DESCRIPTION
Closes #15

* Updates to yarapi 0.2 making it compatible with decentralise market.
* Bumps version to 0.3.
* Adds logging possibilites for yarapi from within gfaas.
* `datadir` attribute is no longer needed - the appkey is taken from the env.